### PR TITLE
fixing youtube.com/get_video_info 404

### DIFF
--- a/timelens-youtube.user.js
+++ b/timelens-youtube.user.js
@@ -11,7 +11,7 @@
 "use strict";
 
 async function getStoryboard(videoId) {
-	let result = await fetch("https://www.youtube.com/get_video_info?video_id="+videoId+"&asv=3&el=detailpage&hl=en_US")
+	let result = await fetch("https://www.youtube.com/get_video_info?video_id="+videoId+"&asv=3&el=detailpage&hl=en_US&html5=1")
 	let text = await result.text();
 	let videoInfo = new URLSearchParams(text);
 	let player_response = videoInfo.get("player_response");


### PR DESCRIPTION
The YouTube endpoint "get_video_info" returning 404 not found.
Source for the fix https://stackoverflow.com/questions/67615278/get-video-info-youtube-endpoint-suddenly-returning-404-not-found